### PR TITLE
add printers that output to stderr

### DIFF
--- a/loggy/lib/loggy.dart
+++ b/loggy/lib/loggy.dart
@@ -4,6 +4,7 @@ import 'dart:async';
 import 'dart:collection';
 
 import 'package:stack_trace/stack_trace.dart' show Trace, Frame;
+import 'package:universal_io/io.dart' show stderr;
 
 part 'src/filters/blacklist_filter.dart';
 part 'src/filters/custom_level_filter.dart';
@@ -14,6 +15,8 @@ part 'src/loggy.dart';
 part 'src/printers/default_printer.dart';
 part 'src/printers/loggy_printer.dart';
 part 'src/printers/pretty_printer.dart';
+part 'src/printers/stderr_pretty_printer.dart';
+part 'src/printers/stderr_printer.dart';
 part 'src/types/loggy_type.dart';
 part 'src/types/types.dart';
 part 'src/util/ansi_color.dart';

--- a/loggy/lib/src/printers/stderr_pretty_printer.dart
+++ b/loggy/lib/src/printers/stderr_pretty_printer.dart
@@ -1,0 +1,32 @@
+part of loggy;
+
+class StdErrPrinter extends PrettyPrinter {
+  const StdErrPrinter() : super();
+
+  @override
+  @override
+  void onLog(LogRecord record) {
+    final time = record.time.toIso8601String().split('T')[1];
+
+    final callerFrame =
+        record.callerFrame == null ? '-' : '(${record.callerFrame?.location})';
+
+    final logLevel = record.level
+        .toString()
+        .replaceAll('Level.', '')
+        .toUpperCase()
+        .padRight(8);
+
+    final color =
+        colorize ? levelColor(record.level) ?? AnsiColor() : AnsiColor();
+
+    final prefix = levelPrefix(record.level) ?? PrettyPrinter.defaultPrefix;
+
+    stderr.writeln(color(
+        '$prefix$time $logLevel ${record.loggerName} $callerFrame ${record.message}'));
+
+    if (record.stackTrace != null) {
+      stderr.writeln('${record.stackTrace}\n');
+    }
+  }
+}

--- a/loggy/lib/src/printers/stderr_printer.dart
+++ b/loggy/lib/src/printers/stderr_printer.dart
@@ -1,0 +1,8 @@
+part of loggy;
+
+class StderrPrinter extends LoggyPrinter {
+  const StderrPrinter() : super();
+
+  @override
+  void onLog(LogRecord record) => stderr.writeln(record);
+}

--- a/loggy/pubspec.yaml
+++ b/loggy/pubspec.yaml
@@ -1,6 +1,6 @@
 name: loggy
 description: Logger for Dart applications, use mixin for easier separation when needed
-version: 2.0.1+1
+version: 2.0.2
 repository: https://github.com/infinum/flutter-logger
 homepage: https://github.com/infinum/flutter-logger
 
@@ -8,7 +8,9 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  stack_trace: '>=1.10.0 <2.0.0'
+  stack_trace: ">=1.10.0 <2.0.0"
+  universal_io: ^2.0.4
 
 dev_dependencies:
-  test: '>1.1.0 <2.0.0'
+  lints: ^2.0.0
+  test: ">1.1.0 <2.0.0"


### PR DESCRIPTION
Hi there,

The code in this PR will allow the use of `stderr` as the IOSink for output to the console.  This is useful in the case of a Dart command line application that uses logging but also needs to pipe output to another command/process.  For instance I use Loggy in my `easy_onvif` package that outputs json to the cli, then I use the `jq` command line utility to parse and display the output.

Since Loggy by default outputs to stdout, sending output that contains logging  to `jq` fails.  However, if the log info is instead output to stderr, the `jq` command will still work, with logging enabled.