### PR TITLE
Preetier LoggyDioInterceptor logs

### DIFF
--- a/flutter_loggy_dio/CHANGELOG.md
+++ b/flutter_loggy_dio/CHANGELOG.md
@@ -1,6 +1,7 @@
-## [3.1.0]
+## [3.1.0] - 07.03.2024
 
 - Removed flutter dependency
+- Prettier logs
 
 ## [3.0.1] - 17.03.2023.
 

--- a/flutter_loggy_dio/lib/flutter_loggy_dio.dart
+++ b/flutter_loggy_dio/lib/flutter_loggy_dio.dart
@@ -1,6 +1,7 @@
 library flutter_loggy_dio;
 
 import 'dart:convert';
+import 'dart:math';
 
 import 'package:dio/dio.dart';
 import 'package:loggy/loggy.dart';

--- a/loggy/README.md
+++ b/loggy/README.md
@@ -219,7 +219,7 @@ In IntelliJ/Studio you can collapse the request/response body:
 ![Gif showing collapsible body][show_body]
 
 
-Set up this is by going to `Preferences -> Editor -> General -> Console` and under `Fold console lines that contain` add these 3 rules: `║`, `╔` and `╚`.
+Set up this is by going to `Preferences -> Editor -> General -> Console` and under `Fold console lines that contain` add these 4 rules: `║`, `╟`, `╔` and `╚`.
 ![Settings][settings]
  
 ## Features and bugs


### PR DESCRIPTION
Preetier `LoggyDioInterceptor` logs.

Example:
```
👻 09:09:43.654922 INFO     DioLoggy - >>> Request │ GET │ https://official-joke-api.appspot.com/random_joke
╔ Query parameters
║
╚════════════════════════════════════════════════════════════════════════════════════════╝
╔ Headers
╟ contentType: null
╟ responseType: ResponseType.plain
╟ followRedirects: true
╟ connectTimeout: null
╟ receiveTimeout: null
╚════════════════════════════════════════════════════════════════════════════════════════╝
╔ Extra
║
╚════════════════════════════════════════════════════════════════════════════════════════╝
👻 09:09:44.738942 INFO     DioLoggy - <<< Response │ GET │ 200 OK │  https://official-joke-api.appspot.com/random_joke
╔ Headers
╟ x-cloud-trace-context: [c365f1d7bce10ccea11402e8267f8945]
╟ x-powered-by: [Express]
╟ alt-svc: [h3=":443"; ma=2592000,h3-29=":443"; ma=2592000]
╟ cache-control: [private]
╟ transfer-encoding: [chunked]
╟ date: [Thu, 07 Mar 2024 08:09:44 GMT]
╟ access-control-allow-origin: [*]
╟ vary: [Accept-Encoding]
╟ content-encoding: [gzip]
╟ etag: [W/"6f-A3GGQoPWVIZeM610/LV0hgl+6Ew"]
╟ content-type: [application/json; charset=utf-8]
╟ server: [Google Frontend]
╚════════════════════════════════════════════════════════════════════════════════════════╝
╔ Body
║ {
║   "type": "general",
║   "setup": "Why did the tree go to the dentist?",
║   "punchline": "It needed a root canal.",
║   "id": 341
║ }
╚════════════════════════════════════════════════════════════════════════════════════════╝
```
