### PR TITLE
Add FilePrinter and MultiPrinter to readme

### DIFF
--- a/loggy/README.md
+++ b/loggy/README.md
@@ -1,17 +1,22 @@
 # Loggy
+
 ![Loggy icon][loggy_image]
 
 Highly customizable logger for dart that uses mixins to show all the needed info.
 
 ## Setup
+
 Add logger package to your project:
+
 ```yaml
 dependencies:
-    loggy: ^2.0.2
+  loggy: ^2.0.2
 ```
 
 ## Usage
+
 Now once you added loggy to your project you can start using it. First, you need to initialize it:
+
 ```dart
 import 'package:loggy/loggy.dart';
 
@@ -22,21 +27,23 @@ main() {
 
 In case you just want to log something without adding mixin you can use `GlobalLoggy` that is accessible everywhere, and it will follow the rules set in `initLoggy` method
 
- ```dart
- import 'package:loggy/loggy.dart';
- 
- class DoSomeWork {
-  DoSomeWork() {
-    logDebug('This is debug message');
-    logInfo('This is info message');
-    logWarning('This is warning message');
-    logError('This is error message');
-  }
+```dart
+import 'package:loggy/loggy.dart';
+
+class DoSomeWork {
+ DoSomeWork() {
+   logDebug('This is debug message');
+   logInfo('This is info message');
+   logWarning('This is warning message');
+   logError('This is error message');
  }
- ```
+}
+```
+
 While global loggy is easier to use, it cannot be easily filtered, and it cannot fetch the calling class.
- 
+
 By using mixins to access our logger, you can get more info from loggy, now I will show you how to use default types (**UiLoggy**, **NetworkLoggy**). Later in the customizing loggy part, I will show you how you can easily add more types depending on the specific use case.
+
 ```dart
 import 'package:loggy/loggy.dart';
 
@@ -51,6 +58,7 @@ class DoSomeWork with UiLoggy {
 ```
 
 As you can see with the magic of mixins you already know the class name from where the log has been called as well as which logger made the call. Now you can use loggy through the app.
+
 ```bash
 [D] UI Loggy - DoSomeWork: This is debug message
 [I] UI Loggy - DoSomeWork: This is info message
@@ -59,6 +67,7 @@ As you can see with the magic of mixins you already know the class name from whe
 ```
 
 Loggy can take anything as it's log message, even closures (they are evaluated only if the log has been shown)
+
 ```dart
 loggy.info(() {
   /// You can do what you want here!
@@ -70,10 +79,13 @@ loggy.info(() {
 ```
 
 ## Customization
+
 ### Printer
+
 Printer or how our log is displayed can be customized a lot, by default loggy will use **DefaultPrinter**, you can replace this by specifying different `logPrinter` on initialization, you can use **PrettyPrinter** that is already included in loggy. You can also easily make your printer by extending the **LoggyPrinter** class.
 
 You can customize logger on init with the following:
+
 ```dart
 import 'package:loggy/loggy.dart';
 
@@ -85,7 +97,9 @@ void main() {
 }
 
 ```
+
 Loggy with **PrettyPrinter**:
+
 ```bash
 🐛 12:22:49.712326 DEBUG    UI Loggy - DoSomeWork - This is debug message
 👻 12:22:49.712369 INFO     UI Loggy - DoSomeWork - This is info message
@@ -93,7 +107,7 @@ Loggy with **PrettyPrinter**:
 ‼️ 12:22:49.712458 ERROR    UI Loggy - DoSomeWork - This is error message
 ```
 
-One useful thing is specifying different printer for release that logs to Crashlytics/Sentry instead of console. 
+One useful thing is specifying different printer for release that logs to Crashlytics/Sentry instead of console.
 
 You could create your own `CrashlyticsPrinter` by extending `Printer` and use it like:
 
@@ -105,11 +119,13 @@ You could create your own `CrashlyticsPrinter` by extending `Printer` and use it
 ```
 
 ### Log options
+
 By providing **LogOptions** you need to specify **LogLevel** that will make sure only levels above what is specified will be shown.
 
 Here you can also control some logging options by changing the `stackTraceLevel`, by specifying level will extract stack trace before the log has been invoked, for all **LogLevel** severities above the specified one.
 
 Setting `stackTraceLevel` to `LogLevel.error`:
+
 ```shell
 🐛 12:26:48.432602 DEBUG    UI Loggy - DoSomeWork - This is debug message
 👻 12:26:48.432642 INFO     UI Loggy - DoSomeWork - This is info message
@@ -124,11 +140,13 @@ Setting `stackTraceLevel` to `LogLevel.error`:
 ```
 
 ### Custom loggers
+
 You can have as many custom loggers as you want, by default you are provided with 2 types:
 **NetworkLoggy** and **UiLoggy**
 
 To make a custom logger you just need to make a new mixin that implements **LoggyType** and
 returns new logger with mixin type:
+
 ```dart
 import 'package:loggy/loggy.dart';
 
@@ -141,13 +159,16 @@ mixin CustomLoggy implements LoggyType {
 Then to use it just add `with CustomLoggy` to the class where you want to use it.
 
 ### Custom log levels
+
 You can add new LogLevel to log like this:
+
 ```dart
 // LogLevel is just a class with `name` and `priority`. Priority can go from 1 - 99 inclusive.
 const LogLevel socketLevel = LogLevel('socket', 32);
 ```
 
 When adding a new level it's also recommended extending the Loggy class as well to add quick function for that level.
+
 ```dart
 extension SocketLoggy on Loggy {
   void socket(dynamic message, [Object error, StackTrace stackTrace]) => log(socketLevel, message, error, stackTrace);
@@ -155,12 +176,71 @@ extension SocketLoggy on Loggy {
 ```
 
 You can now use new log level in the app:
+
 ```dart
 loggy.socket('This is log with socket log level');
 ```
 
+### File logger
+
+You can add a file logger via a extended `LoggyPrinter`.
+
+```dart
+class CustomFilePrinter extends LoggyPrinter {
+  CustomFilePrinter()
+      : file = File('log.txt'),
+        super() {
+    file.create(recursive: true);
+
+    _sink = file.openWrite(
+      mode: FileMode.writeOnly,
+      encoding: utf8,
+    );
+  }
+
+  File file;
+  IOSink? _sink;
+
+  @override
+  void onLog(LogRecord record) async {
+    _sink?.writeln(record.toString());
+    print(record);
+  }
+}
+```
+
+### Multi target logger
+
+You can add a multi target logger via a extended `LoggyPrinter`.
+
+```dart
+class MultiPrinter extends LoggyPrinter{
+  MultiPrinter({
+    required this.consolePrinter,
+    required this.cloudPrinter,
+    required this.filePrinter,
+});
+
+  final LoggyPrinter consolePrinter;
+  final LoggyPrinter cloudPrinter;
+  final LoggyPrinter filePrinter;
+
+  @override
+  void onLog(LogRecord record){
+    consolePrinter.onLog(record);
+    filePrinter.onLog(record);
+
+    // Log to cloud only if app is run in release mode
+    if(kReleaseMode) {
+      cloudPrinter.onLog(record);
+    }
+  }
+}
+```
+
 ### Filtering
-Now you have a lot of different types and levels how to find what you need? You may need to filter some of them. We have **WhitelistFilter**, **BlacklistFilter** and **CustomLevelFilter**. 
+
+Now you have a lot of different types and levels how to find what you need? You may need to filter some of them. We have **WhitelistFilter**, **BlacklistFilter** and **CustomLevelFilter**.
 
 Filtering is a way to limit log output without actually changing or removing existing loggers. Whitelisting some logger types will make sure only logs from that specific type are shown. Blacklisting will do the exact opposite of that. This is useful if your loggers log ton of data and pollute the console so it's hard to see valuable information.
 
@@ -174,17 +254,21 @@ Filtering is a way to limit log output without actually changing or removing exi
 ```
 
 ### More loggers?
+
 Do you need more loggers? No problem!
 
 Any class using Loggy mixin can make new child loggers with `newLoggy(name)` or `detachedLoggy(name)`.
 
 #### Child logger
+
 `newLoggy(name)` will create a new child logger that will be connected to the parent logger and share the same options.
 Child loggy will have parent name included as the prefix on a child's name, divided by `.`.
 
 #### Detached logger
+
 `detachedLoggy(name)` is a logger that has nothing to do with the parent loggy and all options will be ignored.
 If you want to see those logs you need to attach a printer to it.
+
 ```dart
 final _logger = detachedLoggy('Detached logger', logPrinter: DefaultPrinter());
 _logger.level = const LogOptions(LogLevel.all);
@@ -192,42 +276,52 @@ _logger.level = const LogOptions(LogLevel.all);
 ```
 
 ## Loggy 💙 Flutter
+
 Extensions that you can use in Flutter to make our logs look nicer. In order to fully use Loggy features in flutter make sure you are importing `flutter_loggy` pub package. In it you can find printer for flutter console `PrettyDeveloperPrinter` and widget that can show you all the logs: `LoggyStreamWidget`
+
 ### Pretty developer printer
+
 ```
 Loggy.initLoggy(
   logPrinter: PrettyDeveloperPrinter(),
 );
 ```
+
 This printer uses `dart:developer` and can write error messages in red, and it gives us more flexibility. This way you can modify this log a bit more and remove log prefixes (ex. `[        ] I/flutter (21157)`)
 
-To see logs in-app you can use `StreamPrinter` and pass any other printer to it. Now you can use `LoggyStreamWidget` to show logs in a list. 
+To see logs in-app you can use `StreamPrinter` and pass any other printer to it. Now you can use `LoggyStreamWidget` to show logs in a list.
 
 ## Loggy 💙 Dio as well!
+
 Extension for loggy. Includes the interceptor and pretty printer to use with Dio.
-In order to use Dio with Loggy you will have to import `flutter_loggy_dio` package, that will include an interceptor and new loggy type for Dio calls. 
+In order to use Dio with Loggy you will have to import `flutter_loggy_dio` package, that will include an interceptor and new loggy type for Dio calls.
+
 ### Usage
+
 For Dio you included special `DioLoggy` that can be filtered, and `LoggyDioInterceptor` that will connect to Dio and print out requests and responses.
+
 ```dart
 Dio dio = Dio();
 dio.interceptors.add(LoggyDioInterceptor());
 ```
+
 That will use Loggy options and levels, you can change the default `LogLevel` for request, response, and error.
 
 ### Setup
+
 In IntelliJ/Studio you can collapse the request/response body:
 ![Gif showing collapsible body][show_body]
 
-
 Set up this is by going to `Preferences -> Editor -> General -> Console` and under `Fold console lines that contain` add these 4 rules: `║`, `╟`, `╔` and `╚`.
 ![Settings][settings]
- 
+
 ## Features and bugs
+
 Please file feature requests and bugs at the [issue tracker][tracker].
 
 [tracker]: https://github.com/infinum/floggy/issues
 [loggy_image]: https://github.com/infinum/floggy/raw/master/assets/loggy_image.png
-[show_body]: https://github.com/infinum/floggy/raw/master/assets/2020-10-28%2010.38.39.gif 
+[show_body]: https://github.com/infinum/floggy/raw/master/assets/2020-10-28%2010.38.39.gif
 [settings]: https://github.com/infinum/floggy/raw/master/assets/screenshot_settings.png
 
 <p align="center">


### PR DESCRIPTION
Add the solutions from https://github.com/infinum/floggy/issues/50, to the readme.

See `### File logger` (line 184) and `### Multi target logger` (line 212)

The other formatings are auto formatted from vscode prettier. Hope it is ok, that i commit them too. If not i can make an update without the auto-format operations.